### PR TITLE
Handle catalog items with no endpoints

### DIFF
--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -173,15 +173,14 @@ class Cloud:
         #     )
         #     for entry in response.json()["catalog"]
         # }
+        self._endpoints = {}
         try:
             catalog = response.json()["catalog"]
-            endpoints = {}
             for entry in catalog:
-                endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]
-            self._endpoints = endpoints
-        except Exception as exc:
+                self._endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]
+        except StopIteration as exc:
             print(f"Caught: {exc}")
-            raise
+            pass
 
         return self
 

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -171,9 +171,9 @@ class Cloud:
                 for ep in entry["endpoints"]
                 if ep["interface"] == self._interface
             )
-            for entry in response.json()["catalog"] if len(entry["endpoints"]) > 0
+            for entry in response.json()["catalog"]
+            if len(entry["endpoints"]) > 0
         }
-
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -166,24 +166,18 @@ class Cloud:
             else:
                 raise
         try:
-            print(response.json())
             self._endpoints = {
                 entry["type"]: next(
                     ep["url"]
                     for ep in entry["endpoints"]
                     if ep["interface"] == self._interface
                 )
-                for entry in response.json()["catalog"]
+                for entry in response.json()["catalog"] if len(entry["endpoints"]) > 0
             }
-        # self._endpoints = {}
-        # try:
-        #     catalog = response.json()["catalog"]
-        #     for entry in catalog:
-        #         self._endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]
-        except StopIteration as exc:
-            print(f"Caught: {exc}")
-            print(f"Endpoints: {self._endpoints}")
-            pass
+        # except StopIteration as exc:
+        #     print(f"Caught: {exc}")
+        #     print(f"DEBUG: response")
+        #     pass
 
         return self
 

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -166,6 +166,7 @@ class Cloud:
             else:
                 raise
         try:
+            print(response.json())
             self._endpoints = {
                 entry["type"]: next(
                     ep["url"]

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -165,14 +165,23 @@ class Cloud:
                 return self
             else:
                 raise
-        self._endpoints = {
-            entry["type"]: next(
-                ep["url"]
-                for ep in entry["endpoints"]
-                if ep["interface"] == self._interface
-            )
-            for entry in response.json()["catalog"]
-        }
+        # self._endpoints = {
+        #     entry["type"]: next(
+        #         ep["url"]
+        #         for ep in entry["endpoints"]
+        #         if ep["interface"] == self._interface
+        #     )
+        #     for entry in response.json()["catalog"]
+        # }
+        try:
+            catalog = await response.json()["catalog"]
+            endpoints = {}
+            for entry in catalog:
+                endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]
+            self._endpoints = endpoints
+        except Exception as exc:
+            print(f"Caught: {exc}")
+
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -174,7 +174,7 @@ class Cloud:
         #     for entry in response.json()["catalog"]
         # }
         try:
-            catalog = await response.json()["catalog"]
+            catalog = response.json()["catalog"]
             endpoints = {}
             for entry in catalog:
                 endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -174,10 +174,10 @@ class Cloud:
                 )
                 for entry in response.json()["catalog"] if len(entry["endpoints"]) > 0
             }
-        # except StopIteration as exc:
-        #     print(f"Caught: {exc}")
-        #     print(f"DEBUG: response")
-        #     pass
+        except StopIteration as exc:
+            print(f"Caught: {exc}")
+            print(f"DEBUG: response")
+            pass
 
         return self
 

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -165,21 +165,23 @@ class Cloud:
                 return self
             else:
                 raise
-        # self._endpoints = {
-        #     entry["type"]: next(
-        #         ep["url"]
-        #         for ep in entry["endpoints"]
-        #         if ep["interface"] == self._interface
-        #     )
-        #     for entry in response.json()["catalog"]
-        # }
-        self._endpoints = {}
         try:
-            catalog = response.json()["catalog"]
-            for entry in catalog:
-                self._endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]
+            self._endpoints = {
+                entry["type"]: next(
+                    ep["url"]
+                    for ep in entry["endpoints"]
+                    if ep["interface"] == self._interface
+                )
+                for entry in response.json()["catalog"]
+            }
+        # self._endpoints = {}
+        # try:
+        #     catalog = response.json()["catalog"]
+        #     for entry in catalog:
+        #         self._endpoints[entry["type"]] = [ep["url"] for ep in entry["endpoints"] if ep["interface"] == self._interface]
         except StopIteration as exc:
             print(f"Caught: {exc}")
+            print(f"Endpoints: {self._endpoints}")
             pass
 
         return self

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -181,6 +181,7 @@ class Cloud:
             self._endpoints = endpoints
         except Exception as exc:
             print(f"Caught: {exc}")
+            raise
 
         return self
 

--- a/capi_janitor/openstack/openstack.py
+++ b/capi_janitor/openstack/openstack.py
@@ -165,19 +165,14 @@ class Cloud:
                 return self
             else:
                 raise
-        try:
-            self._endpoints = {
-                entry["type"]: next(
-                    ep["url"]
-                    for ep in entry["endpoints"]
-                    if ep["interface"] == self._interface
-                )
-                for entry in response.json()["catalog"] if len(entry["endpoints"]) > 0
-            }
-        except StopIteration as exc:
-            print(f"Caught: {exc}")
-            print(f"DEBUG: response")
-            pass
+        self._endpoints = {
+            entry["type"]: next(
+                ep["url"]
+                for ep in entry["endpoints"]
+                if ep["interface"] == self._interface
+            )
+            for entry in response.json()["catalog"] if len(entry["endpoints"]) > 0
+        }
 
         return self
 


### PR DESCRIPTION
Error seen during cluster deletion on SMS deployment
```
[2023-12-18 15:54:57,436] httpx                [INFO    ] HTTP Request: GET https://<api-url>:5000/v3/auth/catalog "HTTP/1.1 200 OK"
[2023-12-18 15:54:57,437] kopf.objects         [ERROR   ] [az-stackhpc/scott-test-2] coroutine raised StopIteration
Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/openstack.py", line 168, in __aenter__
    self._endpoints = {
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/openstack.py", line 169, in <dictcomp>
    entry["type"]: next(
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 266, in wrapper
    result = await handler(**kwargs)
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 381, in on_openstackcluster_event
    await purge_openstack_resources(
  File "/venv/lib/python3.10/site-packages/capi_janitor/openstack/operator.py", line 152, in purge_openstack_resources
    async with openstack.Cloud.from_clouds(clouds, cacert = cacert) as cloud:
RuntimeError: coroutine raised StopIteration
```